### PR TITLE
Update KeyDemo.Designer.cs

### DIFF
--- a/examples/ch14/Fig14_40/KeyDemo/KeyDemo/KeyDemo.Designer.cs
+++ b/examples/ch14/Fig14_40/KeyDemo/KeyDemo/KeyDemo.Designer.cs
@@ -60,9 +60,9 @@
          this.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
          this.Name = "KeyDemo";
          this.Text = "Key Demo";
-         this.KeyDown += new System.Windows.Forms.KeyEventHandler(this.KeyDemoForm_KeyDown);
-         this.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.KeyDemoForm_KeyPress);
-         this.KeyUp += new System.Windows.Forms.KeyEventHandler(this.KeyDemoForm_KeyUp);
+         this.KeyDown += new System.Windows.Forms.KeyEventHandler(this.KeyDemo_KeyDown);
+         this.KeyPress += new System.Windows.Forms.KeyPressEventHandler(this.KeyDemo_KeyPress);
+         this.KeyUp += new System.Windows.Forms.KeyEventHandler(this.KeyDemo_KeyUp);
          this.ResumeLayout(false);
 
       }


### PR DESCRIPTION
The names generated by VisualStudio follow the class name and the names used were KeyDemo, so KeyDemo_Event, not KeyDemoForm_Event.
Probably would not have noticed this except I was attempting to run the demo program for the first time in 6 years and found it did not compile.